### PR TITLE
remove_facedir_variable

### DIFF
--- a/slopedwalls.lua
+++ b/slopedwalls.lua
@@ -14,7 +14,6 @@ minetest.register_node(":slopedwalls:sloped_wall" .. subname, {
 	tiles = images,
 	paramtype = "light",
 	paramtype2 = "facedir",
-	facedir = simple,
 	groups = groups,
 	sounds = sounds,
 	collision_box = {


### PR DESCRIPTION
remove 'facedir = simple' from line 17 in sloped walls.lua to address https://github.com/TumeniNodes/angledwalls/issues/14